### PR TITLE
Fixed controller roars persisting into loaded savegames

### DIFF
--- a/cs/engine/xrGame/ai/monsters/controller/controller.cpp
+++ b/cs/engine/xrGame/ai/monsters/controller/controller.cpp
@@ -498,7 +498,7 @@ void CController::net_Destroy()
 {
 	inherited::net_Destroy();
 
-	m_aura->on_death	();
+	m_aura->on_destroy	();
 	FreeFromControl		();
 }
 

--- a/cs/engine/xrGame/ai/monsters/controller/controller_psy_aura.cpp
+++ b/cs/engine/xrGame/ai/monsters/controller/controller_psy_aura.cpp
@@ -27,6 +27,11 @@ void CPPEffectorControllerAura::switch_off()
 	m_time_state_started	= Device.dwTimeGlobal;
 }
 
+void CPPEffectorControllerAura::terminate()
+{
+	if (m_snd_left._feedback()) m_snd_left.stop();
+	if (m_snd_right._feedback()) m_snd_right.stop();
+}
 
 BOOL CPPEffectorControllerAura::update()
 {
@@ -169,6 +174,15 @@ void CControllerAura::on_death()
 {
 	if (active()) {
 		m_effector->switch_off	();
+		m_effector				= 0;
+		m_hit_state				= eNone;
+	}
+}
+
+void CControllerAura::on_destroy()
+{
+	if (active()) {
+		m_effector->terminate	();
 		m_effector				= 0;
 		m_hit_state				= eNone;
 	}

--- a/cs/engine/xrGame/ai/monsters/controller/controller_psy_aura.h
+++ b/cs/engine/xrGame/ai/monsters/controller/controller_psy_aura.h
@@ -27,6 +27,7 @@ public:
 					CPPEffectorControllerAura	(const SPPInfo &ppi, u32 time_to_fade, const ref_sound &snd_left, const ref_sound &snd_right);
 	virtual BOOL	update						();
 	void			switch_off					();
+	void			terminate					();
 };
 
 class CControllerAura : public CPPEffectorCustomController<CPPEffectorControllerAura>{
@@ -66,6 +67,7 @@ public:
 	virtual void	load					(LPCSTR section);
 
 			void	on_death				();
+			void	on_destroy				();
 			void	update_schedule			();
 			void	update_frame			();
 };


### PR DESCRIPTION
Per my comment in https://github.com/Decane/SRP/issues/46:

> - In xrGame\ai\monsters\controller\controller.cpp, we have:
> ```
> void CController::net_Destroy()
> {
> 	inherited::net_Destroy();
> 
> 	m_aura->on_death	();
> 	FreeFromControl		();
> }
> ```
> 
> - CControllerAura::on_death() in xrGame\ai\monsters\controller\controller_psy_aura.cpp just calls m_effector->switch_off() and then nullifies pointer m_effector. But it doesn't actually terminate the looped controller roar sounds if they are playing when CController::net_Destroy() is called.

The changes introduced here should fix the problem by forcing an immediate termination of any playing controller roar sounds when CController::net_Destroy() is called, so that they don't persist into the subsequently loaded session.

I have tried to conform as closely as possible to GSC's coding style.